### PR TITLE
small change in import statements

### DIFF
--- a/juego.py
+++ b/juego.py
@@ -5,10 +5,11 @@ import logging
 from pygame.locals import *
 import pygame
 import random
-from gi.repository import Gtk
-import os
 import gi
 gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+import os
+
 
 
 class number(pygame.sprite.Sprite):


### PR DESCRIPTION
writing "from gi.repository import Gtk" statement before "import gi" gives you error sometimes as we are importing Gtk without importing gi (it happened to me)
So, keeping the import statements in this order: 
import gi
gi.require_version('Gtk', '3.0')
from gi.repository import Gtk
This sequence seems to be more logical and works withour errors always
Please review @quozl @llaske @JuiP 