### PR TITLE
UI Enhancement

### DIFF
--- a/juego.py
+++ b/juego.py
@@ -560,30 +560,13 @@ class Game():
                 high_score = puntuacionalta
                 while Gtk.events_pending():
                     Gtk.main_iteration()
-                gameover = self.fuente_60.render(
+                gameover = self.fuente_130.render(
                     get_translated_text(
                         "GAME OVER!!"),
                     True, (255, 255, 255),
                     (0, 0, 0))
-                if score >= high_score:
-                    high_score = score
-                    win = self.fuente_130.render(
-                        get_translated_text("Hurray! you won :)"),
-                        True,
-                        (237, 88, 235),
-                        (0, 0, 0))
-                    win_rect = win.get_rect()
-                    win_rect.center = (sx(600), sy(350))
-                else:
-                    lose = self.fuente_130.render(
-                        get_translated_text("Ay! you lost :("),
-                        True,
-                        (245, 17, 25),
-                        (0, 0, 0))
-                    lose_rect = lose.get_rect()
-                    lose_rect.center = (sx(600), sy(350))
                 score_display = self.fuente_60.render(
-                    get_translated_text("Score : ") + str(score),
+                    get_translated_text("Your Score : ") + str(score),
                     True,
                     (0, 255, 255),
                     (0, 0, 0))
@@ -595,9 +578,9 @@ class Game():
                 gameover_rect = gameover.get_rect()
                 gameover_rect.midtop = (sx(590), sy(100))
                 score_display_rect = score_display.get_rect()
-                score_display_rect.center = (sx(590), sy(500))
+                score_display_rect.center = (sx(590), sy(400))
                 high_score_display_rect = high_score_display.get_rect()
-                high_score_display_rect.midbottom = (sx(590), sy(650))
+                high_score_display_rect.midbottom = (sx(590), sy(550))
                 quit_rect = quit_game.get_rect()
                 quit_rect.topleft = (sx(840), sy(700))
                 play_again_rect = play_again.get_rect()
@@ -609,10 +592,6 @@ class Game():
                     high_score_display, high_score_display_rect)
                 self.screen.blit(quit_game, quit_rect)
                 self.screen.blit(play_again, play_again_rect)
-                if score >= high_score:
-                    self.screen.blit(win, win_rect)
-                else:
-                    self.screen.blit(lose, lose_rect)
                 pygame.display.flip()
             pygame.display.update()
 

--- a/juego.py
+++ b/juego.py
@@ -45,12 +45,14 @@ class expresion:
         self.primero = str(random.randint(0, incremento_nivel[level]))
         self.segundo = str(random.randint(0, incremento_nivel[level]))
         self.expresion = fuente.render(
+            " " +
             self.primero +
             self.simbolo[self.operador] +
             self.segundo +
             " = ? ",
             True,
-            (255, 120, 120))
+            (255, 120, 120),
+            (0, 0, 0))
         self.resultado = str(
             eval(
                 self.primero +
@@ -110,13 +112,15 @@ class expresion:
 
     def update_expression(self, user):
         self.expresion = self.fuente.render(
+            " " +
             self.primero +
             self.simbolo[self.operador] +
             self.segundo +
             " = " +
             user,
             True,
-            (255, 120, 120)
+            (255, 120, 120),
+            (0, 0, 0)
         )
 
 
@@ -429,20 +433,35 @@ class Game():
 
                 nueva_expresion.preguntas.update(
                     time_to_iterate, random.randint(80, 155), level)
-                self.screen.blit(
-                    self.fuente_32.render(
-                        get_translated_text("Score : ") + str(score),
-                        True,
-                        (120, 255, 120)),
-                    (sx(260), 0))
-                self.screen.blit(
-                    self.fuente_32.render(
-                        get_translated_text(
-                            "Highest Score : ") + str(puntuacionalta),
-                        True,
-                        (120, 255, 120)),
-                    (sx(450), 0))
-                self.screen.blit(nueva_expresion.expresion, (sx(200), sy(750)))
+                current_score = self.fuente_32.render(
+                    get_translated_text(" Score : ") +
+                    str(score) +
+                    " ",
+                    True,
+                    (120, 255, 120),
+                    (0, 0, 0))
+
+                high_score = self.fuente_32.render(
+                    get_translated_text(
+                        " Highest Score : ") +
+                    str(puntuacionalta) +
+                    " ",
+                    True,
+                    (120, 255, 120),
+                    (0, 0, 0))
+
+                current_score_rect = current_score.get_rect()
+                current_score_rect.topleft = sx(60), sy(10)
+                self.screen.blit(current_score, current_score_rect)
+
+                high_score_rect = high_score.get_rect()
+                high_score_rect.topleft = sx(60), sy(60)
+                self.screen.blit(high_score, high_score_rect)
+
+                expresion_rect = nueva_expresion.expresion.get_rect()
+                expresion_rect.midtop = sx(600), sy(10)
+                self.screen.blit(nueva_expresion.expresion, expresion_rect)
+
                 for number in (nueva_expresion.correct_number,
                                *nueva_expresion.wrong_numbers):
                     pygame.draw.circle(
@@ -450,12 +469,14 @@ class Game():
                 nueva_expresion.preguntas.draw(self.screen)
                 current_time = max_time_limit - (time.time() - start_time)
                 countdown_time = "{:.2f}".format(current_time)
-                self.screen.blit(
-                    self.fuente_32.render(
-                        get_translated_text("Timer : ") + str(countdown_time),
-                        True,
-                        (120, 255, 120)),
-                    (sx(780), 0))
+                timer = self.fuente_32.render(
+                    get_translated_text(" Timer : ") + str(countdown_time),
+                    True,
+                    (120, 255, 120),
+                    (0, 0, 0))
+                timer_rect = timer.get_rect()
+                timer_rect.topleft = sx(980), sy(10)
+                self.screen.blit(timer, timer_rect)
 
             while Gtk.events_pending():
                 Gtk.main_iteration()


### PR DESCRIPTION


1. Removed displaying lose/win which seemed discouraging. @quozl @chimosky please share your thoughts.
In game over page, comparing the current score with the high score, a text would be rendered saying 'You win' or 'You lose'. I think showing the win/lose would be discouraging to a kid. Instead, just the score and high score could be displayed.
Current game over UI:
![cur_gameover_jamath](https://user-images.githubusercontent.com/43743186/194482705-4c7c3dc2-6d62-4514-b8ff-9a8b9787a1e8.jpeg)

proposed game over UI:
![jamath_gameover_new](https://user-images.githubusercontent.com/43743186/194481986-482a84b1-3609-423f-b02f-657035018094.png)

2.  Improved game page UI; relocated question to the top-centre of the screen for better visibility; added padding to score, high score, question and timer.
Current UI:
![current_UI_jamath](https://user-images.githubusercontent.com/43743186/194482395-6b7749ef-7942-4502-bdff-fa6bc2cc6581.jpeg)

Proposed UI:
![jamath_UI_updated](https://user-images.githubusercontent.com/43743186/194482008-1e2b1b38-c38f-4541-b9d1-379f0d702d86.png)


@quozl @chimosky @srevinsaju  kindly review.