### PR TITLE
"Port to Python 3" - fix download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ JAMath is not a part of the Sugar desktop but can be added.  Please refer to;
 
 * [How to Get Sugar on sugarlabs.org](https://sugarlabs.org/),
 * [How to use Sugar](https://help.sugarlabs.org/),
-* [Download JAMath](https://activities.sugarlabs.org/en-US/sugar/addon/4595).
+* [Download JAMath](https://v4.activities.sugarlabs.org/app/org.ceibaljam.JAMath.html).
 
 Reporting Bugs
 --------------


### PR DESCRIPTION
Update README : fixed download link, now it points to v4 website.