### PR TITLE
Update activity.info - added summary

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -5,4 +5,5 @@ bundle_id = org.ceibaljam.JAMath
 icon = JAMath
 exec = sugar-activity3 JAMath.JAMath
 show_launcher = yes
+summary = A numbers game, where you answer math questions from falling numbers.
 repository = https://github.com/sugarlabs/jamath-activity.git


### PR DESCRIPTION
Since the v4.activities.sugarlabs.org activity card extracts info from this summary. I have added summary to this activity since this is one of the top activities that appear when you open the website, therefore it will look better if this activity has its info available.
![image](https://github.com/user-attachments/assets/334cc426-f336-4d74-bedf-16f0336fa3dc)
